### PR TITLE
Add prefilters. Closes #36

### DIFF
--- a/lib/homepage/component.json
+++ b/lib/homepage/component.json
@@ -21,7 +21,7 @@
     "technologies",
     "user"
   ],
-  "scripts": [ "homepage.js", "view.js" ],
+  "scripts": [ "homepage.js", "view.js", "prefilters.js" ],
   "styles": [ "styles.styl" ],
   "templates": [ "template.jade" ],
   "main": "homepage.js"

--- a/lib/homepage/prefilters.js
+++ b/lib/homepage/prefilters.js
@@ -1,0 +1,32 @@
+
+// TODO: Perhaps this should be on server side (db?), since IDs lives in database
+var prefilters = {
+  'tags': {
+    'transparency': ['552ef377f7692f030000228c'],
+    'data': ['552f46e03ec2bb03001dece7']
+  },
+  'countries': {
+    'argie': ['552ef29bf7692f0300002284']
+  },
+  'technologies': {
+    'web': [
+      '552ef093f7692f030000225b',
+      '552ef091f7692f030000225a',
+      '552ef084f7692f0300002259',
+      '552ef0b4f7692f030000225e',
+      '552ef063f7692f0300002257'
+    ]
+  }
+};
+
+module.exports = {
+  getTagsFor: function (type) {
+    return prefilters['tags'][type] || [];
+  },
+  getCountriesFor: function (type) {
+    return prefilters['countries'][type] || [];
+  },
+  getTechnologiesFor: function (type) {
+    return prefilters['technologies'][type] || [];
+  }
+};

--- a/lib/homepage/styles.styl
+++ b/lib/homepage/styles.styl
@@ -1,4 +1,11 @@
 .homepage
+  .prefilters
+    margin-bottom 30px
+
+    button
+      margin-left 5px
+      margin-right 5px
+
   .filters
     .badge
       margin 0 5px

--- a/lib/homepage/template.jade
+++ b/lib/homepage/template.jade
@@ -1,5 +1,17 @@
 section.homepage
   .container
+    // Prefilters
+    .row.prefilters.col-xs-12.text-center
+      button.btn.btn-sm.btn-default(type='button', on-click='prefilter:transparency')
+        = t('app.prefilter.transparency')
+      button.btn.btn-sm.btn-default(type='button', on-click='prefilter:data')
+        = t('app.prefilter.data')
+      button.btn.btn-sm.btn-default(type='button', on-click='prefilter:argie')
+        = t('app.prefilter.argie')
+      button.btn.btn-sm.btn-default(type='button', on-click='prefilter:web')
+        = t('app.prefilter.web')
+
+    // Search and filters
     .row.homepage-navigation
       .col-xs-12.col-sm-4
         input.form-control.search(type='text' value='{{ filters.search }}' on-keyup='search')
@@ -25,6 +37,8 @@ section.homepage
           on-click="sortBy:{{key}},{{order}}")
           {{title}}
         {{/sorts}}
+
+    // Applied filters badges
     .row.filters: .col-xs-12
       | {{#each selectedCountries}}
       span.badge.filter-country {{ this.name[lang] }}
@@ -41,7 +55,8 @@ section.homepage
         span.filter-remove
           a(on-click="removeFilter:{{'tag'}},{{this.id}}") ×
       | {{/each selectedTags}}
-        
+
+  // Application list
   .container.applications-wrapper
     | {{#filterUpdating}}
     .loading-overlay

--- a/lib/homepage/view.js
+++ b/lib/homepage/view.js
@@ -20,6 +20,7 @@ var user = require('user');
 var language = require('language')();
 var page = require('page');
 var request = require('request');
+var prefilters = require('./prefilters');
 
 /**
  * Expose Homepage
@@ -150,6 +151,13 @@ module.exports = Ractive.extend({
 
       modal.render('body');
       modal.on('close', updateFilters.bind(self));
+    });
+
+    this.on('prefilter', function (ev, type) {
+      this.set('filters.tags', prefilters.getTagsFor(type));
+      this.set('filters.technologies', prefilters.getTechnologiesFor(type));
+      this.set('filters.countries', prefilters.getCountriesFor(type));
+      updateFilters.call(this);
     });
   }
 });


### PR DESCRIPTION
We are adding featured categories as described in #36.
As we don't know which categories will have, I added some examples.

The `lib/homepage/prefilters.js` maps the category groups with the filters them applies.
The `lib/homepage/template.jade` template renders the category buttons, and the view automatically maps the button clicks applying the prefilter information within the homepage filter.

So, If you need to add a new prefilters, just modify the `prefilters.js` by adding a map between the prefilter name and the filter it applies, and add the proper button in the `template.jade`.

Don't forget translations!
