### PR TITLE
Curate application website attribute to include schema

### DIFF
--- a/lib/applications/applications.js
+++ b/lib/applications/applications.js
@@ -12,9 +12,27 @@ approved.on('loaded', function () {
 
   function translate(app) {
     app.description.es = app.description.es || app.description.en;
+    app.website = ensureUrlSchema(app.website);
+  }
+
+  /**
+   * Curates a provided string by prepending the "http://" schema if
+   * it's needed.
+   */
+  function ensureUrlSchema(someurl) {
+      //if the url has no schema (simplified as [characters]://)
+      //then schema is prepended
+      if (someurl && ! /^.*:\/\//i.test(someurl)) {
+        //if url is schema relative (starts with //) then only "http:" is
+        //prepended, otherwise full schema "http://" is used
+        return /^\/\//.test(someurl) ? "http:" + someurl : "http://" + someurl;
+      }
+      return someurl;
   }
 
   approved.items.map(translate);
 });
+
+
 
 module.exports.approved = approved;


### PR DESCRIPTION
Application websites seems to be input with or without schema by
users. Civstack needs was asuming schema (http://) was always
present and links are created in the application based on that
asumption.

This might look like a temporary patch. When the received list
of approved applications is translated a function call was
added to ensure all urls look alike.